### PR TITLE
Secure `profile add` command against overwriting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,9 @@ pub enum ProfileCmd {
         /// Git user email (user.email in gitconfig)
         #[arg(short = 'e', long = "email")]
         user_email: String,
+        /// Override profile if exists
+        #[arg(short, long)]
+        force: bool,
     },
     /// Remove an existing profile
     Remove {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,9 +32,9 @@ fn main() {
                         ProfileCmd::Show { profile } => {
                             println!("{profile:#?}")
                         }
-                        ProfileCmd::Add { name, user_name, user_email } => {
+                        ProfileCmd::Add { name, user_name, user_email, force } => {
                             let profile = Profile::new(name, user_name, user_email);
-                            generate_profile(profile);
+                            generate_profile(profile, force);
                         }
                         ProfileCmd::Remove { profile } => {
                             remove_profile(&profile)

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -7,7 +7,7 @@ use ssh_key::HashAlg;
 
 use crate::profile::error::Error;
 use crate::profile::profile::{Profile, profile_path, profiles_dir};
-use crate::ssh::key::{ED25519, generate_pair, key_pair_exists, private_key_path, public_key_path, regenerate_public_from_private, write_private_key, write_public_key};
+use crate::ssh::key::{ED25519, generate_pair, private_key_path, public_key_path, regenerate_public_from_private, write_private_key, write_public_key};
 
 pub mod profile;
 pub mod error;

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -7,7 +7,7 @@ use ssh_key::HashAlg;
 
 use crate::profile::error::Error;
 use crate::profile::profile::{Profile, profile_path, profiles_dir};
-use crate::ssh::key::{ED25519, generate_pair, private_key_path, public_key_path, write_private_key, write_public_key};
+use crate::ssh::key::{ED25519, generate_pair, key_pair_exists, private_key_path, public_key_path, write_private_key, write_public_key};
 
 pub mod profile;
 pub mod error;
@@ -38,22 +38,25 @@ pub fn list_profiles() -> Vec<String> {
 }
 
 // TODO make this not generate any files if any of the stages fails
-pub fn generate_profile(profile: Profile) {
-    println!("Generating a new ssh-ed25519 key pair");
-    let (private, public) = generate_pair(&profile.user_email);
-    if let Err(e) = write_private_key(&profile.name, &private) { panic!("{}", e.to_string()) }
-    if let Err(e) = write_public_key(&profile.name, &public) { panic!("{}", e.to_string()) }
-    println!("Key pair written");
-    let fingerprint = private.fingerprint(HashAlg::Sha256);
-    let randomart = fingerprint.to_randomart(ED25519);
-    println!("The key fingerprint is:\n{fingerprint}");
-    println!("They key's randomart image is:\n{randomart}");
-    let profiles_dir = profiles_dir();
-    if !Path::new(&profiles_dir).exists() {
-        fs::create_dir_all(profiles_dir).unwrap();
+pub fn generate_profile(profile: Profile, force: bool) {
+    let profile_name = profile.name.clone();
+    let user_email = profile.user_email.clone();
+    let profile_path = profile_path(&profile_name);
+    if Path::new(&profile_path).exists() && !force {
+        println!("Profile '{profile_name}' already exists, if you want to override it, re-run with --force");
+    } else {
+        let profiles_dir = profiles_dir();
+        if !Path::new(&profiles_dir).exists() {
+            fs::create_dir_all(profiles_dir).unwrap();
+        }
+        if let Err(e) = profile.write_json() { panic!("{}", e.to_string()) }
+        println!("Profile written");
     }
-    if let Err(e) = profile.write_json() { panic!("{}", e.to_string()) }
-    println!("Profile written");
+    if key_pair_exists(&profile_name) && !force {
+        println!("ssh keys for profile '{profile_name}' already exist, if you want to re-generate them, re-run with --force");
+        return;
+    }
+    generate_key_pair(&profile_name, &user_email);
 }
 
 pub fn remove_profile(profile_name: &str) {
@@ -77,6 +80,20 @@ pub fn edit_profile(name: String, user_name: Option<String>, user_email: Option<
     }
 }
 
+// TODO this should probably be moved to ssh module
+fn generate_key_pair(profile_name: &str, user_email: &str) {
+    println!("Generating a new ssh-ed25519 key pair");
+    let (private, public) = generate_pair(&user_email);
+    if let Err(e) = write_private_key(&profile_name, &private) { panic!("{}", e.to_string()) }
+    if let Err(e) = write_public_key(&profile_name, &public) { panic!("{}", e.to_string()) }
+    println!("Key pair written");
+    let fingerprint = private.fingerprint(HashAlg::Sha256);
+    let randomart = fingerprint.to_randomart(ED25519);
+    println!("The key fingerprint is:\n{fingerprint}");
+    println!("They key's randomart image is:\n{randomart}");
+}
+
+// TODO this should be moved to some util module
 fn rm_file<P: AsRef<Path> + Display>(path: P) {
     println!("Removing {path}");
     if let Err(_) = fs::remove_file(&path) {

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -52,15 +52,15 @@ pub fn generate_profile(profile: Profile, force: bool) {
         if let Err(e) = profile.write_json() { panic!("{}", e.to_string()) }
         println!("Profile written");
     }
-    if key_pair_exists(&profile_name) && !force {
-        println!("ssh keys for profile '{profile_name}' already exist, if you want to re-generate them, re-run with --force");
-        return;
-    }
     println!("Generating a new ssh-ed25519 key pair");
     let private_path = private_key_path(&profile_name);
-    if Path::new(&private_path).exists() && !force {
-        println!("Found private key, re-generating public key from it.");
-        regenerate_public_from_private(&profile_name).unwrap();
+    if !force {
+        if Path::new(&private_path).exists() {
+            println!("Found private key, re-generating public key from it.");
+            regenerate_public_from_private(&profile_name).unwrap();
+        } else {
+            println!("ssh keys for profile '{profile_name}' already exist, if you want to re-generate them, re-run with --force");
+        }
         return;
     }
     let (private, public) = generate_pair(&user_email);

--- a/src/ssh/error.rs
+++ b/src/ssh/error.rs
@@ -1,11 +1,14 @@
 use std::io;
-use std::time::SystemTime;
 
-use ssh_key::PrivateKey;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
+    #[error("Can't read key: {key_path}")]
+    ReadKey {
+        key_path: String,
+        cause: ssh_key::Error,
+    },
     #[error("Can't write key: {key_path}")]
     WriteKey {
         key_path: String,

--- a/src/ssh/key.rs
+++ b/src/ssh/key.rs
@@ -55,10 +55,3 @@ pub fn public_key_path(profile_name: &str) -> String {
     let ssh_dir = format!("{home}/{SSH_DIR}");
     format!("{ssh_dir}/id_{profile_name}.pub")
 }
-
-pub fn key_pair_exists(profile_name: &str) -> bool {
-    let private_path = private_key_path(profile_name);
-    let public_path = public_key_path(profile_name);
-
-    Path::new(&private_path).exists() && Path::new(&public_path).exists()
-}

--- a/src/ssh/key.rs
+++ b/src/ssh/key.rs
@@ -23,6 +23,15 @@ pub fn generate_pair(user_email: &str) -> (PrivateKey, PublicKey) {
     (private, public)
 }
 
+pub fn regenerate_public_from_private(profile_name: &str) -> Result<()> {
+    let private_key_path = private_key_path(profile_name);
+    let private = PrivateKey::read_openssh_file(Path::new(&private_key_path))
+        .map_err(|cause| Error::ReadKey { key_path: private_key_path, cause })?;
+    let public = PublicKey::from(&private);
+
+    write_public_key(profile_name, &public)
+}
+
 pub fn write_private_key(profile_name: &str, key: &PrivateKey) -> Result<()> {
     let key_path = private_key_path(profile_name);
     key.write_openssh_file(Path::new(&key_path), LineEnding::LF)

--- a/src/ssh/key.rs
+++ b/src/ssh/key.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use rand::thread_rng;
 use ssh_key::{LineEnding, PrivateKey, PublicKey};
 use ssh_key::private::Ed25519Keypair;
+
 use crate::home;
 use crate::ssh::error::Error;
 use crate::ssh::Result;
@@ -44,4 +45,11 @@ pub fn public_key_path(profile_name: &str) -> String {
     let home = home();
     let ssh_dir = format!("{home}/{SSH_DIR}");
     format!("{ssh_dir}/id_{profile_name}.pub")
+}
+
+pub fn key_pair_exists(profile_name: &str) -> bool {
+    let private_path = private_key_path(profile_name);
+    let public_path = public_key_path(profile_name);
+
+    Path::new(&private_path).exists() && Path::new(&public_path).exists()
 }


### PR DESCRIPTION
Now it behaves as before (re-generates everything without asking) only if `--force` flag is specified.

Otherwise, it first looks for the profile `.json`, skipping it's generation if it exists - its contents are not validated against what you've passed for profile creation though, you need to use `profile edit` command for that.
Then it checks if private key exists - if it does, public key is re-generated from it, otherwise whole pair is re-generated from scratch.
