### PR TITLE
Add option to regenerate ssh keys

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,4 +76,6 @@ pub enum ProfileCmd {
         #[arg(short = 'e', long = "email")]
         user_email: Option<String>,
     },
+    /// Re-generate keys for an existing profile
+    Regenerate,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,10 @@ pub enum Cmd {
     /// Switch profiles
     Su {
         /// Name of the profile
-        #[arg(value_parser = | name: & str | Profile::read_json(name))]
+        #[arg(
+            value_parser = | name: & str | Profile::read_json(name)
+            .map_err(| _ | format ! ("Profile '{name}' doesn't exist"))
+        )]
         profile: Profile,
         /// Set the profile for global git config
         #[arg(short, long)]
@@ -77,5 +80,12 @@ pub enum ProfileCmd {
         user_email: Option<String>,
     },
     /// Re-generate keys for an existing profile
-    Regenerate,
+    Regenerate {
+        /// Name of the profile
+        #[arg(
+            value_parser = | name: & str | Profile::read_json(name)
+            .map_err(| _ | format ! ("Profile '{name}' doesn't exist"))
+        )]
+        profile: Profile,
+    },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use crate::cli::{Cli, Cmd, ProfileCmd};
 use crate::git::{configure_user, who_am_i};
 use crate::profile::{add_profile, edit_profile, profile_list, remove_profile, show_profile};
 use crate::profile::profile::Profile;
+use crate::ssh::generate_key_pair;
 
 mod cli;
 mod ssh;
@@ -50,7 +51,9 @@ fn main() {
                         ProfileCmd::Edit { name, user_name, user_email } => {
                             edit_profile(name, user_name, user_email)
                         }
-                        ProfileCmd::Regenerate => {}
+                        ProfileCmd::Regenerate { profile } => {
+                            generate_key_pair(&profile.name, &profile.user_email, true);
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
                         ProfileCmd::Edit { name, user_name, user_email } => {
                             edit_profile(name, user_name, user_email)
                         }
+                        ProfileCmd::Regenerate => {}
                     }
                 }
             }


### PR DESCRIPTION
Added a new cli command: `profile regenerate <PROFILE_NAME>`, which re-generates associated ssh keys.