### PR TITLE
Rework active profile storage

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -31,6 +31,8 @@ pub fn configure_user(profile: &Profile, global: bool) {
 }
 
 pub fn whoami(global: bool) -> Option<String> {
+    let is_inside_repo = is_inside_repo();
+    let global = global || !is_inside_repo;
     if global {
         let profile = ActiveProfile::read_global()?;
         Some(profile.name)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use clap::Parser;
 
 use crate::cli::{Cli, Cmd, ProfileCmd};
-use crate::git::configure_user;
+use crate::git::{configure_user, whoami};
 use crate::profile::{add_profile, edit_profile, profile_list, remove_profile, show_profile};
 use crate::profile::profile::Profile;
 
@@ -23,10 +23,10 @@ fn main() {
                 configure_user(&profile, global)
             }
             Cmd::WhoAmI { global } => {
-                if let Some(profile) = Profile::get_active(global) {
+                if let Some(profile) = whoami(global) {
                     println!("{profile}");
                 } else {
-                    println!("No profile set")
+                    println!("No profile set");
                 }
             }
             Cmd::Profile { command } => {

--- a/src/profile/active.rs
+++ b/src/profile/active.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+use std::fs;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::Path;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::home;
+
+fn active_global_path() -> String {
+    format!("{}/.config/g-profiles/active_global", home())
+}
+
+fn active_local_path() -> String {
+    format!("{}/.config/g-profiles/active_local", home())
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ActiveProfile {
+    pub(crate) name: String,
+    user_name: String,
+    user_email: String,
+    repository: String,
+}
+
+impl ActiveProfile {
+    pub fn new(name: &str, user_name: &str, user_email: &str, repository: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            user_name: user_name.to_string(),
+            user_email: user_email.to_string(),
+            repository: repository.to_string(),
+        }
+    }
+
+
+    pub fn read_global() -> Option<Self> {
+        let path = active_global_path();
+        let json = fs::read(Path::new(&path)).ok()?;
+
+        serde_json::from_slice(json.as_slice()).ok()
+    }
+
+    pub fn read_local(username: &str, email: &str) -> Option<Self> {
+        let mut active_profiles = Self::read_local_list().ok()?;
+
+        active_profiles.remove(&Self::key(username, email))
+    }
+
+    pub fn write_global(self) -> Result<()> {
+        let json = serde_json::to_vec(&self)?;
+        let path = active_global_path();
+        fs::write(Path::new(&path), json.as_slice())?;
+
+        Ok(())
+    }
+
+    pub fn write_local(self) -> Result<()> {
+        let mut active_profiles = Self::read_local_list()?;
+        active_profiles.insert(Self::key(&self.user_name, &self.user_email), self);
+        let path = active_local_path();
+        let json = serde_json::to_vec(&active_profiles)?;
+        fs::write(Path::new(&path), json.as_slice())?;
+
+        Ok(())
+    }
+
+    fn read_local_list() -> Result<HashMap<u64, Self>> {
+        let p = active_local_path();
+        let path = Path::new(&p);
+        if !path.exists() {
+            return Ok(HashMap::new());
+        }
+        let json = fs::read(path)?;
+        let active_profiles = serde_json::from_slice(json.as_slice())?;
+
+        Ok(active_profiles)
+    }
+
+    fn key(username: &str, email: &str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        username.hash(&mut hasher);
+        email.hash(&mut hasher);
+
+        hasher.finish()
+    }
+}

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -9,6 +9,8 @@ use crate::ssh::key::KeyType;
 use crate::util::rm_file;
 
 pub mod profile;
+pub mod active;
+
 const PROFILE_REGEX: &str = r"g-profiles/(?<prof>.+)\.json";
 
 pub fn profile_list() -> Vec<String> {

--- a/src/profile/profile.rs
+++ b/src/profile/profile.rs
@@ -1,8 +1,5 @@
 use std::fmt::{Display, Formatter};
 use std::fs;
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
 
 use anyhow::Result;
 use git2::Config;
@@ -62,19 +59,6 @@ impl Profile {
         Ok((profile_name, partial).into())
     }
 
-    pub fn get_active(global: bool) -> Option<String> {
-        let active_path = Self::active_path(global);
-        fs::read_to_string(Path::new(&active_path)).ok()
-    }
-
-    pub fn set_active(profile_name: &str, global: bool) -> Result<()> {
-        let active_path = Self::active_path(global);
-        let mut file = File::create(Path::new(&active_path))?;
-        file.write(profile_name.as_bytes())?;
-
-        Ok(())
-    }
-
     pub fn write_json(self) -> Result<()> {
         let (profile_name, partial) = self.into();
         let path = profile_path(&profile_name);
@@ -82,14 +66,6 @@ impl Profile {
         fs::write(&path, json)?;
 
         Ok(())
-    }
-
-    fn active_path(global: bool) -> String {
-        if global {
-            format!("{}/active_global", profiles_dir())
-        } else {
-            format!("{}/active", profiles_dir())
-        }
     }
 }
 


### PR DESCRIPTION
Storing globally active profile hasn't changed much, more metadata is stored now.

When it comes to locally active profiles, they're stored as a serialized map now.
Key is hash of username + email pair, as either of those might collide but there's no point creating 2 profiles where both are identical. (if user tries it though, there will be collisions, will need to secure against this obscure edge case in the future just for sanity's sake).

The bug is fixed, but I don't think this PR is the optimal solution, there's lot of data redundancy right now and I think it can be done with less overhead.