### PR TITLE
Enable removing multiple profiles at the same time

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,9 +71,9 @@ pub enum ProfileCmd {
     },
     /// Remove an existing profile
     Remove {
-        /// Name of the profile
+        /// Name of the profile(s)
         #[arg()]
-        profile: String,
+        profiles: Vec<String>,
     },
     /// Edit an existing profile
     Edit {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,10 @@ fn main() {
                             let profile = Profile::new(name, user_name, user_email);
                             add_profile(profile, key_type, force);
                         }
-                        ProfileCmd::Remove { profile } => {
-                            remove_profile(&profile)
+                        ProfileCmd::Remove { profiles } => {
+                            for p in profiles {
+                                remove_profile(&p);
+                            }
                         }
                         ProfileCmd::Edit { name, user_name, user_email } => {
                             edit_profile(name, user_name, user_email)


### PR DESCRIPTION
Little improvement to `profile remove` command - you can now pass list of profile names to remove, not just a single one.